### PR TITLE
ConfigFile update reguest

### DIFF
--- a/client/ClientProxy.java
+++ b/client/ClientProxy.java
@@ -1,73 +1,28 @@
-// 
-// data is in a public static hash table called ConfigFile.settings
-//   ConfigFile.settings.getProperty("myNewBlockID");
-//   ConfigFile.settings.setProperty("myNewBlockID", "1500");
-//
-// config file location is ../config/MineColony.cfg
-//
 package client;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.Properties;
+import net.minecraft.src.World;
+import net.minecraftforge.client.MinecraftForgeClient;
+import server.ServerProxy;
+import cpw.mods.fml.client.FMLClientHandler;
 
-import net.minecraft.client.Minecraft;
+public class ClientProxy extends ServerProxy
+{
 
-public class ConfigFile {
-	
-	public static Properties settings = new Properties();
-	private static String configFilePath="Colony.cfg";
-			
-	public static void createDefaultConfiguration() {
-	   // Default key/value pairs in ConfigFile.settings
-	   settings.setProperty("MineColony", "Reboot");
+	@Override
+    public void registerRenderInformation()
+    {
+        MinecraftForgeClient.preloadTexture("/minecolony.png");
+    }
 
-	   //test purposes
-	   settings.setProperty("townhallID","1000");
-	   //
+    @Override
+    public void registerTileEntitySpecialRenderer(/*PLACEHOLDER*/)
+    {
+       
+    }
 
-           save();
-	}
-	
-	
-	public static void load() {
-	    File configFile = new File(configFilePath);
-	  
-	    try{
-    	      if(configFile.exists() ){
-    	        FileInputStream in = new FileInputStream(configFile);	
-    	        settings.load(in);
-    	      }
-    	      else {
-    	        createDefaultConfiguration();
-   	      }
-
-	   }
-	   catch (Exception e) {
-             System.err.println("[MineColony] " + e.getMessage());
-             System.err.flush();
-           }
-         }
-
-	
-         public static void save() {
-           File configFile = new File(configFilePath);
-           try{
-             configFile.createNewFile();
-             FileOutputStream out = new FileOutputStream(configFile);
-             settings.store(out, "MineColony configuration file");
-             load();
-           }
-           catch (FileNotFoundException e) {
-             System.err.println("[MineColony] " + e.getMessage()+" save,1");
-             System.err.flush();
-           }
-           catch (IOException e){
-             System.err.println("[MineColony] " + e.getMessage()+" save,2");
-             System.err.flush();
-           }
-         }
+    @Override
+    public World getClientWorld()
+    {
+        return FMLClientHandler.instance().getClient().theWorld;
+    }
 }

--- a/client/ClientProxy.java
+++ b/client/ClientProxy.java
@@ -19,7 +19,7 @@ import net.minecraft.client.Minecraft;
 public class ConfigFile {
 	
 	public static Properties settings = new Properties();
-	private static String configFilePath="MineColony.cfg";
+	private static String configFilePath="Colony.cfg";
 			
 	public static void createDefaultConfiguration() {
 	   // Default key/value pairs in ConfigFile.settings

--- a/client/ClientProxy.java
+++ b/client/ClientProxy.java
@@ -1,29 +1,73 @@
+// 
+// data is in a public static hash table called ConfigFile.settings
+//   ConfigFile.settings.getProperty("myNewBlockID");
+//   ConfigFile.settings.setProperty("myNewBlockID", "1500");
+//
+// config file location is ../config/MineColony.cfg
+//
 package client;
 
-import server.ServerProxy;
-import net.minecraftforge.client.MinecraftForgeClient;
-import cpw.mods.fml.client.FMLClientHandler;
-import net.minecraft.src.World;
-import net.minecraftforge.client.MinecraftForgeClient;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Properties;
 
-public class ClientProxy extends ServerProxy
-{
+import net.minecraft.client.Minecraft;
 
-	@Override
-    public void registerRenderInformation()
-    {
-        MinecraftForgeClient.preloadTexture("/minecolony.png");
-    }
+public class ConfigFile {
+	
+	public static Properties settings = new Properties();
+	private static String configFilePath="MineColony.cfg";
+			
+	public static void createDefaultConfiguration() {
+	   // Default key/value pairs in ConfigFile.settings
+	   settings.setProperty("MineColony", "Reboot");
 
-    @Override
-    public void registerTileEntitySpecialRenderer(/*PLACEHOLDER*/)
-    {
-       
-    }
+	   //test purposes
+	   settings.setProperty("townhallID","1000");
+	   //
 
-    @Override
-    public World getClientWorld()
-    {
-        return FMLClientHandler.instance().getClient().theWorld;
-    }
+           save();
+	}
+	
+	
+	public static void load() {
+	    File configFile = new File(configFilePath);
+	  
+	    try{
+    	      if(configFile.exists() ){
+    	        FileInputStream in = new FileInputStream(configFile);	
+    	        settings.load(in);
+    	      }
+    	      else {
+    	        createDefaultConfiguration();
+   	      }
+
+	   }
+	   catch (Exception e) {
+             System.err.println("[MineColony] " + e.getMessage());
+             System.err.flush();
+           }
+         }
+
+	
+         public static void save() {
+           File configFile = new File(configFilePath);
+           try{
+             configFile.createNewFile();
+             FileOutputStream out = new FileOutputStream(configFile);
+             settings.store(out, "MineColony configuration file");
+             load();
+           }
+           catch (FileNotFoundException e) {
+             System.err.println("[MineColony] " + e.getMessage()+" save,1");
+             System.err.flush();
+           }
+           catch (IOException e){
+             System.err.println("[MineColony] " + e.getMessage()+" save,2");
+             System.err.flush();
+           }
+         }
 }

--- a/client/ConfigFile.java
+++ b/client/ConfigFile.java
@@ -1,17 +1,73 @@
-// Create, read and write configuration file
-// stored in user.dir/../config/MineColony.cfg
+// 
+// data is in a public static hash table called ConfigFile.settings
+//   ConfigFile.settings.getProperty("myNewBlockID");
+//   ConfigFile.settings.setProperty("myNewBlockID", "1500");
+//
+// config file location is ../config/MineColony.cfg
+//
 package client;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+import net.minecraft.client.Minecraft;
 
 public class ConfigFile {
 
-	public static void CreateDefaultConfig() {
-			String configFilePath;
-			configFilePath = File.separator +".." + File.separator + "config";
-			// test for and possibly create config folder
-			// test for and possibly create MineColony.cfg
-			// catch exceptions and post to stream
-			// failure to create means use defaults in-game
+	public static Properties settings = new Properties();
+	private static String configFilePath="Colony.cfg";
+
+	public static void createDefaultConfiguration() {
+	   // Default key/value pairs in ConfigFile.settings
+	   settings.setProperty("MineColony", "Reboot");
+
+	   //test purposes
+	   settings.setProperty("townhallID","1000");
+	   //
+
+           save();
 	}
+
+
+	public static void load() {
+	    File configFile = new File(configFilePath);
+
+	    try{
+    	      if(configFile.exists() ){
+    	        FileInputStream in = new FileInputStream(configFile);	
+    	        settings.load(in);
+    	      }
+    	      else {
+    	        createDefaultConfiguration();
+   	      }
+
+	   }
+	   catch (Exception e) {
+             System.err.println("[MineColony] " + e.getMessage());
+             System.err.flush();
+           }
+         }
+
+
+         public static void save() {
+           File configFile = new File(configFilePath);
+           try{
+             configFile.createNewFile();
+             FileOutputStream out = new FileOutputStream(configFile);
+             settings.store(out, "MineColony configuration file");
+             load();
+           }
+           catch (FileNotFoundException e) {
+             System.err.println("[MineColony] " + e.getMessage()+" save,1");
+             System.err.flush();
+           }
+           catch (IOException e){
+             System.err.println("[MineColony] " + e.getMessage()+" save,2");
+             System.err.flush();
+           }
+         }
 }


### PR DESCRIPTION
Made so that file is created and changes how root is find.I shorted 
files name to the Colony since that is now the name :D
Colony.cfg is created at jar folder. MCP folder doesn't exist at 
Minecraft's folder system so config folder folder wouldn't be in ".minecraft". Files will 
automatically go there. No need for root handling. 
I didn't have time to make config folder.

I messed up with files when I was coping code in so "ClientProxy" did come with this : |
